### PR TITLE
Set default window size

### DIFF
--- a/excel_builder.py
+++ b/excel_builder.py
@@ -23,6 +23,7 @@ def build_excel_file(account, my_positions, my_operations, rates_today_cb, marke
     excel_file_name = 'tinkoffReport_' + data_parser.account_data['now_date'].strftime('%Y.%b.%d') + '_'\
                       + account.broker_account_id + '.xlsx'
     workbook = xlsxwriter.Workbook(excel_file_name)
+    workbook.set_size(1440, 1024)  # set default window size
     worksheet_port = workbook.add_worksheet("Portfolio")
     worksheet_ops = workbook.add_worksheet("Operations")
     worksheet_divs = workbook.add_worksheet("Coupons and Dividends")


### PR DESCRIPTION
Устанавливает размер окна при открытии созданного файла.
На МакОС точно, на других системах - возможно, при открытии файлов окошко самого экселя очень маленькое, что раздражает, потому что требуется его растягивать. Данные изменения позволяют задать размер по-больше.